### PR TITLE
TTSのテストを行うためのsampleモデルのディレクトリを変更

### DIFF
--- a/.github/workflows/csharp_test.yml
+++ b/.github/workflows/csharp_test.yml
@@ -57,4 +57,5 @@ jobs:
     - run: |
         cp open_jtalk_dic_utf_8-1.11.tar.gz ./tests/VoicevoxCoreSharp.Core.Tests/resources
         tar zxf ./tests/VoicevoxCoreSharp.Core.Tests/resources/open_jtalk_dic_utf_8-1.11.tar.gz -C tests/VoicevoxCoreSharp.Core.Tests/resources/
+    - run: cp -r binding/voicevox_core/model ./tests/VoicevoxCoreSharp.Core.Tests/resources
     - run: dotnet test

--- a/tests/VoicevoxCoreSharp.Core.Tests/Consts.cs
+++ b/tests/VoicevoxCoreSharp.Core.Tests/Consts.cs
@@ -6,6 +6,6 @@ namespace VoicevoxCoreSharp.Core.Tests
     public class Consts
     {
         public static readonly string OpenJTalkDictDir = Path.Combine(Helper.GetProjectDirectory(), "resources", "open_jtalk_dic_utf_8-1.11");
-        public static readonly string SampleVoiceModel = Path.Combine(Helper.GetBaseVoicevoxCoreDirectory(), "model", "sample.vvm");
+        public static readonly string SampleVoiceModel = Path.Combine(Helper.GetProjectDirectory(), "resources", "model", "sample.vvm");
     }
 }


### PR DESCRIPTION
fat_resourceを扱う時でも同じディレクトリで出来ると楽なので、resourcesディレクトリベースの読み込みに変える