### PR TITLE
OnnxRuntimeはCoreの依存に含めない

### DIFF
--- a/examples/cli/cli.csproj
+++ b/examples/cli/cli.csproj
@@ -4,8 +4,17 @@
     <ProjectReference Include="..\..\src\VoicevoxCoreSharp.Core\VoicevoxCoreSharp.Core.csproj" />
   </ItemGroup>
 
+  <!--
+    VoicevoxOnnxRuntimeVersion の Property を取得するために使用している
+    csproj 内で Property を設定すれば不要
+    またNugetからOnnxRuntimeを取得せずに、voicevox_core に同梱されているものを使用する場合は不要
+    その際は PackageReference から Microsoft.ML.OnnxRuntime を削除し、配置のための Content を変更すること
+  -->
+  <Import Project="..\..\src\VoicevoxCoreSharp.Core\VoicevoxCoreSharp.Core.Metas.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(VoicevoxOnnxRuntimeVersion)" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
@@ -52,12 +61,6 @@
       <!-- Not supported OS or Architecture -->
     </Otherwise>
   </Choose>
-
-  <!--
-    VoicevoxOnnxRuntimeVersion の Property を取得するために使用している
-    csproj 内で Property を設定すれば不要
-  -->
-  <Import Project="..\..\src\VoicevoxCoreSharp.Core\VoicevoxCoreSharp.Core.Metas.props" />
 
   <!--
     Testsではnativeディレクトリに配置しているが、

--- a/src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.csproj
+++ b/src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.csproj
@@ -9,8 +9,4 @@
 
   <Import Project="VoicevoxCoreSharp.Core.Metas.props" />
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(VoicevoxOnnxRuntimeVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/tests/VoicevoxCoreSharp.Core.Tests/VoicevoxCoreSharp.Core.Tests.csproj
+++ b/tests/VoicevoxCoreSharp.Core.Tests/VoicevoxCoreSharp.Core.Tests.csproj
@@ -8,7 +8,10 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <Import Project="..\..\src\VoicevoxCoreSharp.Core\VoicevoxCoreSharp.Core.Metas.props" />
+
   <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(VoicevoxOnnxRuntimeVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -61,8 +64,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\VoicevoxCoreSharp.Core\VoicevoxCoreSharp.Core.csproj" />
   </ItemGroup>
-
-  <Import Project="..\..\src\VoicevoxCoreSharp.Core\VoicevoxCoreSharp.Core.Metas.props" />
 
   <ItemGroup>
     <Content Include="resources\libvoicevox_core.dylib" TargetPath="runtimes\$(_MyRuntimeIdentifier)\native\libvoicevox_core.dylib" Visible="false" CopyToOutputDirectory="PreserveNewest" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />


### PR DESCRIPTION
MAUI版のexampleを作っている時に、入れることができなかった。
Content要素とかでのコピーのやり方さえ書いておけばどうにでもなるので消してしまおう。