### PR TITLE
squashがdefaultだったけど、通常mergeしていた

### DIFF
--- a/.github/workflows/testing-queue.yml
+++ b/.github/workflows/testing-queue.yml
@@ -49,6 +49,7 @@ jobs:
           base-branch: ${{ needs.PreTesting.outputs.base-branch }}
           base-branch-sha: ${{ needs.PreTesting.outputs.base-branch-sha }}
           pr-number: ${{ github.event.inputs.issue_number }}
+          merge-method: 'squash'
       - run:
           git push origin --delete ${{ github.event.inputs.tmp-ci-branch }}
         env:


### PR DESCRIPTION
https://stackoverflow.com/questions/63253397/how-to-get-the-default-merge-method-for-a-pull-request-from-github-graphql-query/64146400#64146400

みたいに、ユーザに紐づいた方法を取得できるけど、人によって変わるのは微妙なのでworkflowで指定できるようにする