### PR TITLE
Release 0.16.0

### DIFF
--- a/src/VoicevoxCoreSharp.Core.Unity/package.json
+++ b/src/VoicevoxCoreSharp.Core.Unity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev.yamachu.voicevoxcoresharpcoreunity",
   "author": "yamachu",
-  "version": "0.0.1",
+  "version": "0.16.0",
   "displayName": "VoicevoxCoreSharp.Core.Unity",
   "description": "VoicevoxCoreSharp.Core for Unity",
   "unity": "2021.3"


### PR DESCRIPTION
GitHub ActionsでReleaseしたいけれども、一度自前でリリースしてTokenなどを取得する必要があるっぽそうなのでPRに起こす。
UnityのPackageはpackage.jsonのアップデートが必要であるため変更している。

## Core

```sh
dotnet pack -p:PackageVersion=0.16.0 -c Release
```

## MAUI

```sh
dotnet pack -p:CoreVersion=0.16.0 -p:PackageVersion=0.16.0 -c Release
```
