### PR TITLE
Update submodule

### DIFF
--- a/binding/Makefile
+++ b/binding/Makefile
@@ -5,8 +5,8 @@ generate:
 	$(MAKE) replace-hash
 
 replace-hash:
-	$(eval VERSION := $(shell cat ../.git/modules/binding/voicevox_core/HEAD))
-	$(shell sed -i.bak 's/<VoicevoxCoreCommitHash>.*<\/VoicevoxCoreCommitHash>/<VoicevoxCoreCommitHash>$(VERSION)<\/VoicevoxCoreCommitHash>/' ../src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.Metas.props)
+	$(eval VERSION := $(shell git -C voicevox_core rev-parse HEAD))
+	$(shell sed -i.bak 's|<VoicevoxCoreCommitHash>.*</VoicevoxCoreCommitHash>|<VoicevoxCoreCommitHash>$(VERSION)</VoicevoxCoreCommitHash>|' ../src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.Metas.props)
 
 build/dev-library:
 	cd voicevox_core; cargo build --release -p voicevox_core_c_api --features load-onnxruntime -F voicevox_core/buildtime-download-onnxruntime

--- a/examples/UnitySample/Assets/SampleVoicevoxCoreSharpScript.cs
+++ b/examples/UnitySample/Assets/SampleVoicevoxCoreSharpScript.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -50,7 +50,7 @@ public class SampleVoicevoxCoreSharpScript : MonoBehaviour
             return;
         }
 
-        result = synthesizer.LoadVoiceModel(voiceModel);
+        result = synthesizer.LoadVoiceModel(voiceModel, LoadVoiceModelOptions.Default());
         if (result != ResultCode.RESULT_OK)
         {
             Debug.LogError(result.ToMessage());

--- a/examples/cli/Program.cs
+++ b/examples/cli/Program.cs
@@ -1,10 +1,9 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Parsing;
 using Microsoft.Extensions.FileSystemGlobbing;
-
 using VoicevoxCoreSharp.Core;
-using VoicevoxCoreSharp.Core.Struct;
 using VoicevoxCoreSharp.Core.Enum;
+using VoicevoxCoreSharp.Core.Struct;
 
 const string OutputWavName = "audio.wav";
 const uint StyleId = 0;
@@ -50,7 +49,7 @@ static int RunTts(string text, string? resourcePath = "voicevox_core")
             return 1;
         }
 
-        result = synthesizer.LoadVoiceModel(voiceModel);
+        result = synthesizer.LoadVoiceModel(voiceModel, LoadVoiceModelOptions.Default());
         if (result != ResultCode.RESULT_OK)
         {
             Console.Error.WriteLine(result.ToMessage());

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Enum/OnExistingVoiceModelId.cs
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Enum/OnExistingVoiceModelId.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using VoicevoxCoreSharp.Core.Native;
+
+namespace VoicevoxCoreSharp.Core.Enum
+{
+    /// <summary>
+    /// ::voicevox_synthesizer_load_voice_model の実行時に、同じIDの ::VoicevoxVoiceModelFile が既に読み込まれていたときのふるまい。
+    /// </summary>
+    public enum OnExistingVoiceModelId : int
+    {
+        /// <summary>
+        /// エラーにする。デフォルトのふるまい
+        /// </summary>
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR = 0,
+        /// <summary>
+        /// 再読み込みする。VOICEVOX COREでは、長文のテキストを一度に音声合成するとCPU/GPUメモリが大量に占有されたままになる。再読み込みを行うとメモリの使用量が元に戻る
+        /// </summary>
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD = 1,
+        /// <summary>
+        /// 何もしない
+        /// </summary>
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP = 2,
+    }
+
+    internal static class OnExistingVoiceModelIdExt
+    {
+        public static OnExistingVoiceModelId FromNative(this VoicevoxOnExistingVoiceModelId mode)
+        {
+#pragma warning disable CS8524
+            return mode switch
+            {
+                VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR => OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR,
+                VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD => OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD,
+                VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP => OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP,
+            };
+#pragma warning restore CS8524
+        }
+
+        public static VoicevoxOnExistingVoiceModelId ToNative(this OnExistingVoiceModelId mode)
+        {
+#pragma warning disable CS8524
+            return mode switch
+            {
+                OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR => VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR,
+                OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD => VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD,
+                OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP => VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP,
+            };
+#pragma warning restore CS8524
+        }
+    }
+}

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Enum/OnExistingVoiceModelId.cs.meta
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Enum/OnExistingVoiceModelId.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93999e01ea9a84867bd270baa5886bc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Native/CoreUnsafe.g.cs
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Native/CoreUnsafe.g.cs
@@ -536,17 +536,27 @@ namespace VoicevoxCoreSharp.Core.Native
         internal static extern void voicevox_synthesizer_delete(VoicevoxSynthesizer* synthesizer);
 
         /// <summary>
+        ///  デフォルトの `voicevox_synthesizer_load_voice_model` のオプションを生成する
+        ///  @return デフォルト値が設定された `voicevox_synthesizer_load_voice_model` のオプション
+        ///
+        ///  \no-orig-impl{voicevox_make_default_load_voice_model_options}
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "voicevox_make_default_load_voice_model_options", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern VoicevoxLoadVoiceModelOptions voicevox_make_default_load_voice_model_options();
+
+        /// <summary>
         ///  音声モデルを読み込む。
         ///
         ///  @param [in] synthesizer 音声シンセサイザ
         ///  @param [in] model 音声モデル
+        ///  @param [in] options オプション
         ///
         ///  @returns 結果コード
         ///
         ///  \orig-impl{voicevox_synthesizer_load_voice_model}
         /// </summary>
         [DllImport(__DllName, EntryPoint = "voicevox_synthesizer_load_voice_model", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern VoicevoxResultCode voicevox_synthesizer_load_voice_model(VoicevoxSynthesizer* synthesizer, VoicevoxVoiceModelFile* model);
+        internal static extern VoicevoxResultCode voicevox_synthesizer_load_voice_model(VoicevoxSynthesizer* synthesizer, VoicevoxVoiceModelFile* model, VoicevoxLoadVoiceModelOptions options);
 
         /// <summary>
         ///  音声モデルの読み込みを解除する。
@@ -1375,6 +1385,12 @@ namespace VoicevoxCoreSharp.Core.Native
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    internal unsafe partial struct VoicevoxLoadVoiceModelOptions
+    {
+        public VoicevoxOnExistingVoiceModelId on_existing;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal unsafe partial struct VoicevoxSynthesisOptions
     {
         [MarshalAs(UnmanagedType.U1)] public bool enable_interrogative_upspeak;
@@ -1435,6 +1451,13 @@ namespace VoicevoxCoreSharp.Core.Native
         VOICEVOX_RESULT_INVALID_FRAME_AUDIO_QUERY_ERROR = 33,
         VOICEVOX_RESULT_INVALID_FRAME_PHONEME_ERROR = 34,
         VOICEVOX_RESULT_INCOMPATIBLE_QUERIES_ERROR = 35,
+    }
+
+    internal enum VoicevoxOnExistingVoiceModelId : int
+    {
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR = 0,
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD = 1,
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP = 2,
     }
 
     internal enum VoicevoxAccelerationMode : int

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Struct/LoadVoiceModelOptions.cs
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Struct/LoadVoiceModelOptions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using VoicevoxCoreSharp.Core.Enum;
+using VoicevoxCoreSharp.Core.Native;
+
+namespace VoicevoxCoreSharp.Core.Struct
+{
+    /// <summary>
+    /// ::voicevox_synthesizer_load_voice_model のオプション。
+    /// </summary>
+    public struct LoadVoiceModelOptions
+    {
+        /// <summary>
+        /// 同じIDの ::VoicevoxVoiceModelFile が既に読み込まれていたときのふるまい
+        /// </summary>
+        public OnExistingVoiceModelId OnExisting { get; set; }
+
+        public static LoadVoiceModelOptions Default()
+        {
+            return LoadVoiceModelOptionsDefault.Value;
+        }
+    }
+
+    internal static class LoadVoiceModelOptionsDefault
+    {
+        public static readonly LoadVoiceModelOptions Value = CoreUnsafe.voicevox_make_default_load_voice_model_options().FromNative();
+    }
+
+    internal static class LoadVoiceModelOptionsExt
+    {
+        internal static VoicevoxLoadVoiceModelOptions ToNative(this LoadVoiceModelOptions loadVoiceModelOptions)
+        {
+            return new VoicevoxLoadVoiceModelOptions
+            {
+                on_existing = loadVoiceModelOptions.OnExisting.ToNative()
+            };
+        }
+
+        internal static LoadVoiceModelOptions FromNative(this VoicevoxLoadVoiceModelOptions loadVoiceModelOptions)
+        {
+            return new LoadVoiceModelOptions
+            {
+                OnExisting = loadVoiceModelOptions.on_existing.FromNative()
+            };
+        }
+    }
+}

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Struct/LoadVoiceModelOptions.cs.meta
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Struct/LoadVoiceModelOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c4ed9e54fb1b4886b2741165ca0d74d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Synthesizer.cs
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Synthesizer.cs
@@ -60,11 +60,12 @@ namespace VoicevoxCoreSharp.Core
             }
         }
 
-        public ResultCode LoadVoiceModel(VoiceModelFile voiceModel)
+        public ResultCode LoadVoiceModel(VoiceModelFile voiceModel, LoadVoiceModelOptions options)
         {
             unsafe
             {
-                return CoreUnsafe.voicevox_synthesizer_load_voice_model((VoicevoxSynthesizer*)Handle, (VoicevoxVoiceModelFile*)voiceModel.Handle).FromNative();
+                var loadVoiceModelOptions = options.ToNative();
+                return CoreUnsafe.voicevox_synthesizer_load_voice_model((VoicevoxSynthesizer*)Handle, (VoicevoxVoiceModelFile*)voiceModel.Handle, loadVoiceModelOptions).FromNative();
             }
         }
 

--- a/src/VoicevoxCoreSharp.Core/Enum/OnExistingVoiceModelId.cs
+++ b/src/VoicevoxCoreSharp.Core/Enum/OnExistingVoiceModelId.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using VoicevoxCoreSharp.Core.Native;
+
+namespace VoicevoxCoreSharp.Core.Enum
+{
+    /// <summary>
+    /// ::voicevox_synthesizer_load_voice_model の実行時に、同じIDの ::VoicevoxVoiceModelFile が既に読み込まれていたときのふるまい。
+    /// </summary>
+    public enum OnExistingVoiceModelId : int
+    {
+        /// <summary>
+        /// エラーにする。デフォルトのふるまい
+        /// </summary>
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR = 0,
+        /// <summary>
+        /// 再読み込みする。VOICEVOX COREでは、長文のテキストを一度に音声合成するとCPU/GPUメモリが大量に占有されたままになる。再読み込みを行うとメモリの使用量が元に戻る
+        /// </summary>
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD = 1,
+        /// <summary>
+        /// 何もしない
+        /// </summary>
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP = 2,
+    }
+
+    internal static class OnExistingVoiceModelIdExt
+    {
+        public static OnExistingVoiceModelId FromNative(this VoicevoxOnExistingVoiceModelId mode)
+        {
+#pragma warning disable CS8524
+            return mode switch
+            {
+                VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR => OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR,
+                VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD => OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD,
+                VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP => OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP,
+            };
+#pragma warning restore CS8524
+        }
+
+        public static VoicevoxOnExistingVoiceModelId ToNative(this OnExistingVoiceModelId mode)
+        {
+#pragma warning disable CS8524
+            return mode switch
+            {
+                OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR => VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR,
+                OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD => VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD,
+                OnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP => VoicevoxOnExistingVoiceModelId.VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP,
+            };
+#pragma warning restore CS8524
+        }
+    }
+}

--- a/src/VoicevoxCoreSharp.Core/Native/CoreUnsafe.g.cs
+++ b/src/VoicevoxCoreSharp.Core/Native/CoreUnsafe.g.cs
@@ -536,17 +536,27 @@ namespace VoicevoxCoreSharp.Core.Native
         internal static extern void voicevox_synthesizer_delete(VoicevoxSynthesizer* synthesizer);
 
         /// <summary>
+        ///  デフォルトの `voicevox_synthesizer_load_voice_model` のオプションを生成する
+        ///  @return デフォルト値が設定された `voicevox_synthesizer_load_voice_model` のオプション
+        ///
+        ///  \no-orig-impl{voicevox_make_default_load_voice_model_options}
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "voicevox_make_default_load_voice_model_options", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern VoicevoxLoadVoiceModelOptions voicevox_make_default_load_voice_model_options();
+
+        /// <summary>
         ///  音声モデルを読み込む。
         ///
         ///  @param [in] synthesizer 音声シンセサイザ
         ///  @param [in] model 音声モデル
+        ///  @param [in] options オプション
         ///
         ///  @returns 結果コード
         ///
         ///  \orig-impl{voicevox_synthesizer_load_voice_model}
         /// </summary>
         [DllImport(__DllName, EntryPoint = "voicevox_synthesizer_load_voice_model", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern VoicevoxResultCode voicevox_synthesizer_load_voice_model(VoicevoxSynthesizer* synthesizer, VoicevoxVoiceModelFile* model);
+        internal static extern VoicevoxResultCode voicevox_synthesizer_load_voice_model(VoicevoxSynthesizer* synthesizer, VoicevoxVoiceModelFile* model, VoicevoxLoadVoiceModelOptions options);
 
         /// <summary>
         ///  音声モデルの読み込みを解除する。
@@ -1375,6 +1385,12 @@ namespace VoicevoxCoreSharp.Core.Native
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    internal unsafe partial struct VoicevoxLoadVoiceModelOptions
+    {
+        public VoicevoxOnExistingVoiceModelId on_existing;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal unsafe partial struct VoicevoxSynthesisOptions
     {
         [MarshalAs(UnmanagedType.U1)] public bool enable_interrogative_upspeak;
@@ -1435,6 +1451,13 @@ namespace VoicevoxCoreSharp.Core.Native
         VOICEVOX_RESULT_INVALID_FRAME_AUDIO_QUERY_ERROR = 33,
         VOICEVOX_RESULT_INVALID_FRAME_PHONEME_ERROR = 34,
         VOICEVOX_RESULT_INCOMPATIBLE_QUERIES_ERROR = 35,
+    }
+
+    internal enum VoicevoxOnExistingVoiceModelId : int
+    {
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_ERROR = 0,
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_RELOAD = 1,
+        VOICEVOX_ON_EXISTING_VOICE_MODEL_ID_SKIP = 2,
     }
 
     internal enum VoicevoxAccelerationMode : int

--- a/src/VoicevoxCoreSharp.Core/Struct/LoadVoiceModelOptions.cs
+++ b/src/VoicevoxCoreSharp.Core/Struct/LoadVoiceModelOptions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using VoicevoxCoreSharp.Core.Enum;
+using VoicevoxCoreSharp.Core.Native;
+
+namespace VoicevoxCoreSharp.Core.Struct
+{
+    /// <summary>
+    /// ::voicevox_synthesizer_load_voice_model のオプション。
+    /// </summary>
+    public struct LoadVoiceModelOptions
+    {
+        /// <summary>
+        /// 同じIDの ::VoicevoxVoiceModelFile が既に読み込まれていたときのふるまい
+        /// </summary>
+        public OnExistingVoiceModelId OnExisting { get; set; }
+
+        public static LoadVoiceModelOptions Default()
+        {
+            return LoadVoiceModelOptionsDefault.Value;
+        }
+    }
+
+    internal static class LoadVoiceModelOptionsDefault
+    {
+        public static readonly LoadVoiceModelOptions Value = CoreUnsafe.voicevox_make_default_load_voice_model_options().FromNative();
+    }
+
+    internal static class LoadVoiceModelOptionsExt
+    {
+        internal static VoicevoxLoadVoiceModelOptions ToNative(this LoadVoiceModelOptions loadVoiceModelOptions)
+        {
+            return new VoicevoxLoadVoiceModelOptions
+            {
+                on_existing = loadVoiceModelOptions.OnExisting.ToNative()
+            };
+        }
+
+        internal static LoadVoiceModelOptions FromNative(this VoicevoxLoadVoiceModelOptions loadVoiceModelOptions)
+        {
+            return new LoadVoiceModelOptions
+            {
+                OnExisting = loadVoiceModelOptions.on_existing.FromNative()
+            };
+        }
+    }
+}

--- a/src/VoicevoxCoreSharp.Core/Synthesizer.cs
+++ b/src/VoicevoxCoreSharp.Core/Synthesizer.cs
@@ -60,11 +60,12 @@ namespace VoicevoxCoreSharp.Core
             }
         }
 
-        public ResultCode LoadVoiceModel(VoiceModelFile voiceModel)
+        public ResultCode LoadVoiceModel(VoiceModelFile voiceModel, LoadVoiceModelOptions options)
         {
             unsafe
             {
-                return CoreUnsafe.voicevox_synthesizer_load_voice_model((VoicevoxSynthesizer*)Handle, (VoicevoxVoiceModelFile*)voiceModel.Handle).FromNative();
+                var loadVoiceModelOptions = options.ToNative();
+                return CoreUnsafe.voicevox_synthesizer_load_voice_model((VoicevoxSynthesizer*)Handle, (VoicevoxVoiceModelFile*)voiceModel.Handle, loadVoiceModelOptions).FromNative();
             }
         }
 

--- a/src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.Metas.props
+++ b/src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.Metas.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <VoicevoxOnnxRuntimeVersion>1.17.3</VoicevoxOnnxRuntimeVersion>
-        <VoicevoxCoreCommitHash>cdb9ab6e3c2fe6421d20af3fd2a476878ecf79c0</VoicevoxCoreCommitHash>
+        <VoicevoxCoreCommitHash>72dde0a885e91f94dff0de7377b1851a809eefa9</VoicevoxCoreCommitHash>
     </PropertyGroup>
 </Project>

--- a/src/VoicevoxCoreSharp.Experimental/SynthesizerExtensions.cs
+++ b/src/VoicevoxCoreSharp.Experimental/SynthesizerExtensions.cs
@@ -9,7 +9,7 @@ namespace VoicevoxCoreSharp.Experimental
     public static partial class SynthesizerExtensions
     {
         [NonBlocking]
-        public static partial Task LoadVoiceModelAsync(this Synthesizer synthesizer, VoiceModelFile voiceModel);
+        public static partial Task LoadVoiceModelAsync(this Synthesizer synthesizer, VoiceModelFile voiceModel, LoadVoiceModelOptions options);
 
         [NonBlocking]
         public static partial Task<(nuint outputWavLength, byte[] outputWav)> SynthesisAsync(this Synthesizer synthesizer, string audioQueryJson, uint styleId, SynthesisOptions options);

--- a/tests/VoicevoxCoreSharp.Core.Tests/SynthesizerTest.cs
+++ b/tests/VoicevoxCoreSharp.Core.Tests/SynthesizerTest.cs
@@ -21,7 +21,7 @@ namespace VoicevoxCoreSharp.Core.Tests
             var synthesizerResult = Synthesizer.New(onnruntime, openJtalk, initializeOptions, out var synthesizer);
 
             VoiceModelFile.Open(Consts.SampleVoiceModel, out var voiceModel);
-            var loadResult = synthesizer.LoadVoiceModel(voiceModel);
+            var loadResult = synthesizer.LoadVoiceModel(voiceModel, LoadVoiceModelOptions.Default());
 
             Assert.Equal(ResultCode.RESULT_OK, synthesizerResult);
             Assert.Equal(ResultCode.RESULT_OK, loadResult);
@@ -47,7 +47,7 @@ namespace VoicevoxCoreSharp.Core.Tests
             Synthesizer.New(onnruntime, openJtalk, initializeOptions, out var synthesizer);
 
             VoiceModelFile.Open(Consts.SampleVoiceModel, out var voiceModel);
-            synthesizer.LoadVoiceModel(voiceModel);
+            synthesizer.LoadVoiceModel(voiceModel, LoadVoiceModelOptions.Default());
 
             Assert.True(synthesizer.IsLoadedVoiceModel(voiceModel.Id));
             synthesizer.UnloadVoiceModel(voiceModel.Id);
@@ -63,7 +63,7 @@ namespace VoicevoxCoreSharp.Core.Tests
             Onnxruntime.LoadOnce(onnxruntimeOptions, out var onnxruntime);
             Synthesizer.New(onnxruntime, openJtalk, initializeOptions, out var synthesizer);
             VoiceModelFile.Open(Consts.SampleVoiceModel, out var voiceModel);
-            synthesizer.LoadVoiceModel(voiceModel);
+            synthesizer.LoadVoiceModel(voiceModel, LoadVoiceModelOptions.Default());
 
             var score = """
             {

--- a/tests/VoicevoxCoreSharp.Core.Tests/TtsTest.cs
+++ b/tests/VoicevoxCoreSharp.Core.Tests/TtsTest.cs
@@ -21,7 +21,7 @@ namespace VoicevoxCoreSharp.Core.Tests
             var synthesizerResult = Synthesizer.New(onnruntime, openJtalk, initializeOptions, out var synthesizer);
 
             VoiceModelFile.Open(Consts.SampleVoiceModel, out var voiceModel);
-            var loadResult = synthesizer.LoadVoiceModel(voiceModel);
+            var loadResult = synthesizer.LoadVoiceModel(voiceModel, LoadVoiceModelOptions.Default());
 
             Assert.Equal(ResultCode.RESULT_OK, synthesizerResult);
             Assert.Equal(ResultCode.RESULT_OK, loadResult);


### PR DESCRIPTION
https://github.com/VOICEVOX/voicevox_core/pull/1337
load_voice_modelの対応が入ったため、引数の変更が行われた

これをmergeした次のバージョンでは
VoicevoxCoreSharp.Experimental
のdependentなVoicevoxCoreSharpのバージョンを上げる必要があるのに注意

