### PR TITLE
SampleのUnityプロジェクトで開き直したら、metaファイル周りが足りてないのが見つかったので足す

### DIFF
--- a/src/VoicevoxCoreSharp.Core.Unity/.gitignore
+++ b/src/VoicevoxCoreSharp.Core.Unity/.gitignore
@@ -17,6 +17,12 @@
 /[Pp]roject[Ss]ettings/
 *.log
 
+/Assets.meta
+/Logs.meta
+/Packages.meta
+/ProjectSettings.meta
+/UserSettings.meta
+
 # By default unity supports Blender asset imports, *.blend1 blender files do not need to be commited to version control.
 *.blend1
 *.blend1.meta


### PR DESCRIPTION
https://github.com/yamachu/VoicevoxCoreSharp/pull/298
で作業したけど、SampleProjectで開いてなくて、ignoreしたディレクトリのmetaファイルが生成されるのに気づけなかった