### PR TITLE
Update submodule（voicevox_core 0.17.0 対応）

### DIFF
--- a/.github/workflows/csharp_test.yml
+++ b/.github/workflows/csharp_test.yml
@@ -85,7 +85,7 @@ jobs:
         mkdir -p ./examples/cli/voicevox_core/c_api/lib
         mkdir -p ./examples/cli/voicevox_core/onnxruntime/lib
         cp ./binding/voicevox_core/target/release/libvoicevox_core.so ./examples/cli/voicevox_core/c_api/lib/libvoicevox_core.so
-        cp ./binding/voicevox_core/target/release/libonnxruntime.so ./examples/cli/voicevox_core/onnxruntime/lib/libonnxruntime.so.1.17.3
+        cp ./binding/voicevox_core/target/release/libonnxruntime.so ./examples/cli/voicevox_core/onnxruntime/lib/libonnxruntime.so.1.23.2
     - uses: ./.github/composite/download-openjtalk-dict
       with:
         cache-path: open_jtalk_dic_utf_8-1.11.tar.gz

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ $ dotnet add package VoicevoxCoreSharp.Core
 ```
 
 Unity の場合は Package Manager から以下の URL を追加してください。
-`#0.16.0` はバージョンを指定しています。
+`#0.17.0` はバージョンを指定しています。
 
 ```
-https://github.com/yamachu/VoicevoxCoreSharp.git?path=/src/VoicevoxCoreSharp.Core.Unity#0.16.0
+https://github.com/yamachu/VoicevoxCoreSharp.git?path=/src/VoicevoxCoreSharp.Core.Unity#0.17.0
 ```
 
 MAUI の場合は以下のパッケージを追加すると便利です。

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -25,4 +25,4 @@ https://github.com/yamachu/VoicevoxCoreSharp/pull/264
 
 #### 0.17.0
 
-TODO
+https://github.com/yamachu/VoicevoxCoreSharp/pull/315

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,7 +10,8 @@
 | 0.16.0 - 0.16.1   | 0.16.1        |
 | 0.16.0 - 0.16.1   | 0.16.2        |
 | 0.16.2 - 0.16.2   | 0.16.3        |
-| 0.16.3 -          | 0.16.4        |
+| 0.16.3            | 0.16.4        |
+| 0.17.0 -          | 0.17.0        |
 
 ### 対応したPR
 
@@ -21,3 +22,7 @@ https://github.com/yamachu/VoicevoxCoreSharp/pull/252
 #### 0.16.3
 
 https://github.com/yamachu/VoicevoxCoreSharp/pull/264
+
+#### 0.17.0
+
+TODO

--- a/examples/MAUI/MAUI.csproj
+++ b/examples/MAUI/MAUI.csproj
@@ -90,10 +90,10 @@
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
     <!-- NOTE: downloaderが未対応なため、voicevox_core/android というディレクトリを生やして、そこに格納している -->
     <!-- https://developer.android.com/ndk/guides/abis?hl=ja -->
-    <AndroidNativeLibrary Include="voicevox_core/android/voicevox_onnxruntime-android-arm64-1.17.3/lib/libvoicevox_onnxruntime.so">
+    <AndroidNativeLibrary Include="voicevox_core/android/voicevox_onnxruntime-android-arm64-1.23.2/lib/libvoicevox_onnxruntime.so">
       <Abi>arm64-v8a</Abi>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="voicevox_core/android/voicevox_onnxruntime-android-x64-1.17.3/lib/libvoicevox_onnxruntime.so">
+    <AndroidNativeLibrary Include="voicevox_core/android/voicevox_onnxruntime-android-x64-1.23.2/lib/libvoicevox_onnxruntime.so">
       <Abi>x86_64</Abi>
     </AndroidNativeLibrary>
         <AndroidNativeLibrary Include="voicevox_core/android/voicevox_core-android-arm64-0.16.0/lib/libvoicevox_core.so">

--- a/examples/MAUI/MAUI.csproj
+++ b/examples/MAUI/MAUI.csproj
@@ -96,10 +96,10 @@
     <AndroidNativeLibrary Include="voicevox_core/android/voicevox_onnxruntime-android-x64-1.23.2/lib/libvoicevox_onnxruntime.so">
       <Abi>x86_64</Abi>
     </AndroidNativeLibrary>
-        <AndroidNativeLibrary Include="voicevox_core/android/voicevox_core-android-arm64-0.16.0/lib/libvoicevox_core.so">
+        <AndroidNativeLibrary Include="voicevox_core/android/voicevox_core-android-arm64-0.17.0/lib/libvoicevox_core.so">
       <Abi>arm64-v8a</Abi>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="voicevox_core/android/voicevox_core-android-x86_64-0.16.0/lib/libvoicevox_core.so">
+    <AndroidNativeLibrary Include="voicevox_core/android/voicevox_core-android-x86_64-0.17.0/lib/libvoicevox_core.so">
       <Abi>x86_64</Abi>
     </AndroidNativeLibrary>
     <AndroidNativeLibrary Include="$(ANDROID_NDK_SYSROOT)/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so">

--- a/examples/MAUI/MainPageViewModel.cs
+++ b/examples/MAUI/MainPageViewModel.cs
@@ -56,7 +56,7 @@ public partial class MainPageViewModel : ObservableObject
         var libraryPath = "";
 #if MACCATALYST
         var bundlePath = Foundation.NSBundle.MainBundle.BundlePath;
-        libraryPath = Path.Combine(bundlePath, "Contents", "MonoBundle", "libvoicevox_onnxruntime.1.17.3.dylib");
+        libraryPath = Path.Combine(bundlePath, "Contents", "MonoBundle", "libvoicevox_onnxruntime.1.23.2.dylib");
 #elif ANDROID
         var bundlePath = Android.App.Application.Context.ApplicationInfo?.NativeLibraryDir;
         libraryPath = Path.Combine(bundlePath, "libvoicevox_onnxruntime.so");
@@ -107,7 +107,7 @@ public partial class MainPageViewModel : ObservableObject
         var libraryPath = "";
 #if MACCATALYST
         var bundlePath = Foundation.NSBundle.MainBundle.BundlePath;
-        libraryPath = Path.Combine(bundlePath, "Contents", "MonoBundle", "libvoicevox_onnxruntime.1.17.3.dylib");
+        libraryPath = Path.Combine(bundlePath, "Contents", "MonoBundle", "libvoicevox_onnxruntime.1.23.2.dylib");
 #elif ANDROID
         var bundlePath = Android.App.Application.Context.ApplicationInfo?.NativeLibraryDir;
         libraryPath = Path.Combine(bundlePath, "libvoicevox_onnxruntime.so");

--- a/examples/MAUI/README.md
+++ b/examples/MAUI/README.md
@@ -20,7 +20,7 @@ $ download-osx-arm64 --only models dict -o ./examples/MAUI/voicevox_core
 #### macOS
 
 ```sh
-$ download-osx-arm64 --c-api-version 0.16.0 --onnxruntime-version voicevox_onnxruntime-1.17.3 -o ./examples/MAUI/voicevox_core
+$ download-osx-arm64 --c-api-version 0.16.0 --onnxruntime-version voicevox_onnxruntime-1.23.2 -o ./examples/MAUI/voicevox_core
 ```
 
 #### Android / iOS
@@ -28,7 +28,7 @@ $ download-osx-arm64 --c-api-version 0.16.0 --onnxruntime-version voicevox_onnxr
 Download `voicevox_core` and `onnxruntime` from the following URL.
 
 - https://github.com/VOICEVOX/voicevox_core/releases/tag/0.16.0
-- https://github.com/VOICEVOX/onnxruntime-builder/releases/tag/voicevox_onnxruntime-1.17.3
+- https://github.com/VOICEVOX/onnxruntime-builder/releases/tag/voicevox_onnxruntime-1.23.2
 
 and extract them to `./examples/MAUI/voicevox_core`.
 

--- a/examples/MAUI/README.md
+++ b/examples/MAUI/README.md
@@ -1,6 +1,6 @@
 # MAUI Sample
 
-voicevox_core 0.16.0 を使用した MAUI サンプルです。
+voicevox_core 0.17.0 を使用した MAUI サンプルです。
 
 ## Usage
 
@@ -20,14 +20,14 @@ $ download-osx-arm64 --only models dict -o ./examples/MAUI/voicevox_core
 #### macOS
 
 ```sh
-$ download-osx-arm64 --c-api-version 0.16.0 --onnxruntime-version voicevox_onnxruntime-1.23.2 -o ./examples/MAUI/voicevox_core
+$ download-osx-arm64 --c-api-version 0.17.0 --onnxruntime-version voicevox_onnxruntime-1.23.2 -o ./examples/MAUI/voicevox_core
 ```
 
 #### Android / iOS
 
 Download `voicevox_core` and `onnxruntime` from the following URL.
 
-- https://github.com/VOICEVOX/voicevox_core/releases/tag/0.16.0
+- https://github.com/VOICEVOX/voicevox_core/releases/tag/0.17.0
 - https://github.com/VOICEVOX/onnxruntime-builder/releases/tag/voicevox_onnxruntime-1.23.2
 
 and extract them to `./examples/MAUI/voicevox_core`.

--- a/examples/UnitySample/Assets/SampleVoicevoxCoreSharpScript.cs
+++ b/examples/UnitySample/Assets/SampleVoicevoxCoreSharpScript.cs
@@ -28,7 +28,7 @@ public class SampleVoicevoxCoreSharpScript : MonoBehaviour
         }
 
         // TODO: This is platform dependent code, FIXME
-        var loadOnnxruntimeOptions = new LoadOnnxruntimeOptions(Path.Combine(Application.dataPath, "Plugins", "runtimes", "osx.10.14-arm64", "native", "libvoicevox_onnxruntime.1.17.3.dylib"));
+        var loadOnnxruntimeOptions = new LoadOnnxruntimeOptions(Path.Combine(Application.dataPath, "Plugins", "runtimes", "osx.10.14-arm64", "native", "libvoicevox_onnxruntime.1.23.2.dylib"));
         if (Onnxruntime.LoadOnce(loadOnnxruntimeOptions, out var onnxruntime) != ResultCode.RESULT_OK)
         {
             Debug.LogError("Failed to initialize onnxruntime");

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -12,7 +12,7 @@ https://github.com/VOICEVOX/voicevox_core/tree/main/example/cpp/unix を参考�
 
 ```sh
 # macOS Arm64の場合
-$ ./download-osx-arm64 --c-api-version 0.16.0 --onnxruntime-version voicevox_onnxruntime-1.17.3 -o voicevox_core
+$ ./download-osx-arm64 --c-api-version 0.16.0 --onnxruntime-version voicevox_onnxruntime-1.23.2 -o voicevox_core
 ```
 
 このリポジトリは voicevox_core の main ブランチに追従しているため、examples/cli のコードが動作しない場合もあります。

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -12,7 +12,7 @@ https://github.com/VOICEVOX/voicevox_core/tree/main/example/cpp/unix を参考�
 
 ```sh
 # macOS Arm64の場合
-$ ./download-osx-arm64 --c-api-version 0.16.0 --onnxruntime-version voicevox_onnxruntime-1.23.2 -o voicevox_core
+$ ./download-osx-arm64 --c-api-version 0.17.0 --onnxruntime-version voicevox_onnxruntime-1.23.2 -o voicevox_core
 ```
 
 このリポジトリは voicevox_core の main ブランチに追従しているため、examples/cli のコードが動作しない場合もあります。

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Enum/ResultCode.cs
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Enum/ResultCode.cs
@@ -71,7 +71,7 @@ namespace VoicevoxCoreSharp.Core.Enum
         /// <summary>
         /// モデルの形式が不正
         /// </summary>
-        RESULT_INVALID_MODEL_HEADER_ERROR = 28,
+        RESULT_INVALID_MODEL_FORMAT_ERROR = 28,
         /// <summary>
         /// すでに読み込まれている音声モデルを読み込もうとした
         /// </summary>
@@ -156,7 +156,7 @@ namespace VoicevoxCoreSharp.Core.Enum
                 VoicevoxResultCode.VOICEVOX_RESULT_INVALID_ACCENT_PHRASE_ERROR => ResultCode.RESULT_INVALID_ACCENT_PHRASE_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_OPEN_ZIP_FILE_ERROR => ResultCode.RESULT_OPEN_ZIP_FILE_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_READ_ZIP_ENTRY_ERROR => ResultCode.RESULT_READ_ZIP_ENTRY_ERROR,
-                VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_HEADER_ERROR => ResultCode.RESULT_INVALID_MODEL_HEADER_ERROR,
+                VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_FORMAT_ERROR => ResultCode.RESULT_INVALID_MODEL_FORMAT_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_MODEL_ALREADY_LOADED_ERROR => ResultCode.RESULT_MODEL_ALREADY_LOADED_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_STYLE_ALREADY_LOADED_ERROR => ResultCode.RESULT_STYLE_ALREADY_LOADED_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_DATA_ERROR => ResultCode.RESULT_INVALID_MODEL_DATA_ERROR,
@@ -196,7 +196,7 @@ namespace VoicevoxCoreSharp.Core.Enum
                 ResultCode.RESULT_INVALID_ACCENT_PHRASE_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_INVALID_ACCENT_PHRASE_ERROR,
                 ResultCode.RESULT_OPEN_ZIP_FILE_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_OPEN_ZIP_FILE_ERROR,
                 ResultCode.RESULT_READ_ZIP_ENTRY_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_READ_ZIP_ENTRY_ERROR,
-                ResultCode.RESULT_INVALID_MODEL_HEADER_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_HEADER_ERROR,
+                ResultCode.RESULT_INVALID_MODEL_FORMAT_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_FORMAT_ERROR,
                 ResultCode.RESULT_MODEL_ALREADY_LOADED_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_MODEL_ALREADY_LOADED_ERROR,
                 ResultCode.RESULT_STYLE_ALREADY_LOADED_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_STYLE_ALREADY_LOADED_ERROR,
                 ResultCode.RESULT_INVALID_MODEL_DATA_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_DATA_ERROR,

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Native/CoreUnsafe.g.cs
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Native/CoreUnsafe.g.cs
@@ -22,30 +22,50 @@ namespace VoicevoxCoreSharp.Core.Native
 
 
         /// <summary>
-        ///  ONNX Runtimeの動的ライブラリの、バージョン付きのファイル名。
+        ///  必要なONNX Runtime 1.xの最小マイナーバージョンを取得する。
         ///
-        ///  WindowsとAndroidでは ::voicevox_get_onnxruntime_lib_unversioned_filename と同じ。
+        ///  @return 必要な最小マイナーバージョン
         ///
-        ///  \availability{
-        ///    [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は&lt;a href="#voicevox-core-availability"&gt;ファイルレベルの"Availability"の節&lt;/a&gt;を参照。
-        ///  }
-        ///
-        ///  \orig-impl{voicevox_get_onnxruntime_lib_versioned_filename}
+        ///  \orig-impl{voicevox_get_onnxruntime_lib_min_required_minor_version}
         /// </summary>
-        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_versioned_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern byte* voicevox_get_onnxruntime_lib_versioned_filename();
+        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_min_required_minor_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern uint voicevox_get_onnxruntime_lib_min_required_minor_version();
 
         /// <summary>
-        ///  ONNX Runtimeの動的ライブラリの、バージョン無しのファイル名。
+        ///  サポートされるONNX Runtime 1.xの最大マイナーバージョンを取得する。
+        ///
+        ///  @return サポートされる最大マイナーバージョン
+        ///
+        ///  \orig-impl{voicevox_get_onnxruntime_lib_max_supported_minor_version}
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_max_supported_minor_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern uint voicevox_get_onnxruntime_lib_max_supported_minor_version();
+
+        /// <summary>
+        ///  推奨されるONNX Runtimeの動的ライブラリの、バージョン付きのファイル名。
+        ///
+        ///  WindowsとAndroidでは ::voicevox_get_onnxruntime_lib_recommended_unversioned_filename と同じ。
         ///
         ///  \availability{
         ///    [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は&lt;a href="#voicevox-core-availability"&gt;ファイルレベルの"Availability"の節&lt;/a&gt;を参照。
         ///  }
         ///
-        ///  \orig-impl{voicevox_get_onnxruntime_lib_unversioned_filename}
+        ///  \orig-impl{voicevox_get_onnxruntime_lib_recommended_versioned_filename}
         /// </summary>
-        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_unversioned_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern byte* voicevox_get_onnxruntime_lib_unversioned_filename();
+        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_recommended_versioned_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern byte* voicevox_get_onnxruntime_lib_recommended_versioned_filename();
+
+        /// <summary>
+        ///  推奨されるONNX Runtimeの動的ライブラリの、バージョン無しのファイル名。
+        ///
+        ///  \availability{
+        ///    [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は&lt;a href="#voicevox-core-availability"&gt;ファイルレベルの"Availability"の節&lt;/a&gt;を参照。
+        ///  }
+        ///
+        ///  \orig-impl{voicevox_get_onnxruntime_lib_recommended_unversioned_filename}
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_recommended_unversioned_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern byte* voicevox_get_onnxruntime_lib_recommended_unversioned_filename();
 
         /// <summary>
         ///  デフォルトの ::voicevox_onnxruntime_load_once のオプションを生成する。
@@ -76,6 +96,8 @@ namespace VoicevoxCoreSharp.Core.Native
         /// <summary>
         ///  ONNX Runtimeをロードして初期化する。
         ///
+        ///  対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_minor_version 以上でなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
+        ///
         ///  一度成功したら、以後は引数を無視して同じ参照を返す。
         ///
         ///  @param [in] options オプション
@@ -99,6 +121,8 @@ namespace VoicevoxCoreSharp.Core.Native
 
         /// <summary>
         ///  ONNX Runtimeを初期化する。
+        ///
+        ///  リンクされているONNX Runtimeのマイナーバージョンが ::voicevox_get_onnxruntime_lib_min_required_minor_version よりも小さい場合失敗する。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
         ///
         ///  一度成功したら以後は同じ参照を返す。
         ///
@@ -236,19 +260,13 @@ namespace VoicevoxCoreSharp.Core.Native
         ///
         ///  - [Rust APIの`AudioQuery`型]としてデシリアライズ不可、もしくはJSONとして不正。
         ///  - `accent_phrases`の要素のうちいずれかが、 ::voicevox_accent_phrase_validate でエラーになる。
-        ///  - `outputSamplingRate`が`24000`の倍数ではない、もしくは`0` (将来的に解消予定。cf. [#762])。
         ///
         ///  [Rust APIの`AudioQuery`型]: ../rust_api/voicevox_core/struct.AudioQuery.html
         ///  [#762]: https://github.com/VOICEVOX/voicevox_core/issues/762
         ///
         ///  次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
         ///
-        ///  - `accent_phrases`の要素のうちいずれかが警告が出る状態。
-        ///  - `speedScale`が負。
-        ///  - `volumeScale`が負。
-        ///  - `prePhonemeLength`が負。
-        ///  - `postPhonemeLength`が負。
-        ///  - `outputSamplingRate`が`24000`以外の値（エラーと同様将来的に解消予定）。
+        ///  - `outputSamplingRate`が`24000`以外の値（将来的に解消予定。cf. [#762]）。
         ///
         ///  @param [in] audio_query_json `AudioQuery`型のJSON
         ///
@@ -270,14 +288,9 @@ namespace VoicevoxCoreSharp.Core.Native
         ///
         ///  - [Rust APIの`AccentPhrase`型]としてデシリアライズ不可、もしくはJSONとして不正。
         ///  - `moras`もしくは`pause_mora`の要素のうちいずれかが、 ::voicevox_mora_validate でエラーになる。
-        ///  - `accent`が`0`。
+        ///  - `accent`が`moras`の数を超過している。
         ///
         ///  [Rust APIの`AccentPhrase`型]: ../rust_api/voicevox_core/struct.AccentPhrase.html
-        ///
-        ///  次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
-        ///
-        ///  - `moras`もしくは`pause_mora`の要素のうちいずれかが、警告が出る状態。
-        ///  - `accent`が`moras`の数を超過している。
         ///
         ///  @param [in] accent_phrase_json `AccentPhrase`型のJSON
         ///
@@ -299,15 +312,8 @@ namespace VoicevoxCoreSharp.Core.Native
         ///
         ///  - [Rust APIの`Mora`型]としてデシリアライズ不可、もしくはJSONとして不正。
         ///  - `consonant`と`consonant_length`の有無が不一致。
-        ///  - `consonant`が子音以外の音素であるか、もしくは音素として不正。
-        ///  - `vowel`が子音であるか、もしくは音素として不正。
         ///
         ///  [Rust APIの`Mora`型]: ../rust_api/voicevox_core/struct.Mora.html
-        ///
-        ///  次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
-        ///
-        ///  - `consonant_length`が負。
-        ///  - `vowel_length`が負。
         ///
         ///  @param [in] mora_json `Mora`型のJSON
         ///
@@ -1414,7 +1420,7 @@ namespace VoicevoxCoreSharp.Core.Native
         public byte* pronunciation;
         public nuint accent_type;
         public VoicevoxUserDictWordType word_type;
-        public uint priority;
+        public byte priority;
     }
 
 
@@ -1435,7 +1441,7 @@ namespace VoicevoxCoreSharp.Core.Native
         VOICEVOX_RESULT_INVALID_ACCENT_PHRASE_ERROR = 15,
         VOICEVOX_RESULT_OPEN_ZIP_FILE_ERROR = 16,
         VOICEVOX_RESULT_READ_ZIP_ENTRY_ERROR = 17,
-        VOICEVOX_RESULT_INVALID_MODEL_HEADER_ERROR = 28,
+        VOICEVOX_RESULT_INVALID_MODEL_FORMAT_ERROR = 28,
         VOICEVOX_RESULT_MODEL_ALREADY_LOADED_ERROR = 18,
         VOICEVOX_RESULT_STYLE_ALREADY_LOADED_ERROR = 26,
         VOICEVOX_RESULT_INVALID_MODEL_DATA_ERROR = 27,

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Onnxruntime.cs
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Onnxruntime.cs
@@ -38,19 +38,35 @@ namespace VoicevoxCoreSharp.Core
             Handle = new OnnxruntimeHandle(new IntPtr(onnxruntimeHandle));
         }
 
-        public static string GetVersionedFilename()
+        public static uint GetMinRequiredMinorVersion()
         {
             unsafe
             {
-                return StringConvertCompat.ToUTF8String(CoreUnsafe.voicevox_get_onnxruntime_lib_versioned_filename());
+                return CoreUnsafe.voicevox_get_onnxruntime_lib_min_required_minor_version();
             }
         }
 
-        public static string GetUnversionedFilename()
+        public static uint GetMaxSupportedMinorVersion()
         {
             unsafe
             {
-                return StringConvertCompat.ToUTF8String(CoreUnsafe.voicevox_get_onnxruntime_lib_unversioned_filename());
+                return CoreUnsafe.voicevox_get_onnxruntime_lib_max_supported_minor_version();
+            }
+        }
+
+        public static string GetRecommendedVersionedFilename()
+        {
+            unsafe
+            {
+                return StringConvertCompat.ToUTF8String(CoreUnsafe.voicevox_get_onnxruntime_lib_recommended_versioned_filename());
+            }
+        }
+
+        public static string GetRecommendedUnversionedFilename()
+        {
+            unsafe
+            {
+                return StringConvertCompat.ToUTF8String(CoreUnsafe.voicevox_get_onnxruntime_lib_recommended_unversioned_filename());
             }
         }
 

--- a/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Struct/UserDictWord.cs
+++ b/src/VoicevoxCoreSharp.Core.Unity/Runtime/Script/Struct/UserDictWord.cs
@@ -38,7 +38,7 @@ namespace VoicevoxCoreSharp.Core.Struct
         /// <summary>
         /// 優先度
         /// </summary>
-        public uint Priority { get; set; }
+        public byte Priority { get; set; }
 
         public static UserDictWord Create(string surface, string pronunciation, nuint accentType)
         {

--- a/src/VoicevoxCoreSharp.Core.Unity/VoicevoxCoreSharp.Core.Unity.asmdef
+++ b/src/VoicevoxCoreSharp.Core.Unity/VoicevoxCoreSharp.Core.Unity.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "VoicevoxCoreSharp.Core.Unity",
-    "rootNamespace": "VoicevoxCoreShap.Core",
+    "rootNamespace": "VoicevoxCoreSharp.Core",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/src/VoicevoxCoreSharp.Core.Unity/package.json
+++ b/src/VoicevoxCoreSharp.Core.Unity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev.yamachu.voicevoxcoresharpcoreunity",
   "author": "yamachu",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "displayName": "VoicevoxCoreSharp.Core.Unity",
   "description": "VoicevoxCoreSharp.Core for Unity",
   "unity": "2022.3"

--- a/src/VoicevoxCoreSharp.Core/Enum/ResultCode.cs
+++ b/src/VoicevoxCoreSharp.Core/Enum/ResultCode.cs
@@ -71,7 +71,7 @@ namespace VoicevoxCoreSharp.Core.Enum
         /// <summary>
         /// モデルの形式が不正
         /// </summary>
-        RESULT_INVALID_MODEL_HEADER_ERROR = 28,
+        RESULT_INVALID_MODEL_FORMAT_ERROR = 28,
         /// <summary>
         /// すでに読み込まれている音声モデルを読み込もうとした
         /// </summary>
@@ -156,7 +156,7 @@ namespace VoicevoxCoreSharp.Core.Enum
                 VoicevoxResultCode.VOICEVOX_RESULT_INVALID_ACCENT_PHRASE_ERROR => ResultCode.RESULT_INVALID_ACCENT_PHRASE_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_OPEN_ZIP_FILE_ERROR => ResultCode.RESULT_OPEN_ZIP_FILE_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_READ_ZIP_ENTRY_ERROR => ResultCode.RESULT_READ_ZIP_ENTRY_ERROR,
-                VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_HEADER_ERROR => ResultCode.RESULT_INVALID_MODEL_HEADER_ERROR,
+                VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_FORMAT_ERROR => ResultCode.RESULT_INVALID_MODEL_FORMAT_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_MODEL_ALREADY_LOADED_ERROR => ResultCode.RESULT_MODEL_ALREADY_LOADED_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_STYLE_ALREADY_LOADED_ERROR => ResultCode.RESULT_STYLE_ALREADY_LOADED_ERROR,
                 VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_DATA_ERROR => ResultCode.RESULT_INVALID_MODEL_DATA_ERROR,
@@ -196,7 +196,7 @@ namespace VoicevoxCoreSharp.Core.Enum
                 ResultCode.RESULT_INVALID_ACCENT_PHRASE_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_INVALID_ACCENT_PHRASE_ERROR,
                 ResultCode.RESULT_OPEN_ZIP_FILE_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_OPEN_ZIP_FILE_ERROR,
                 ResultCode.RESULT_READ_ZIP_ENTRY_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_READ_ZIP_ENTRY_ERROR,
-                ResultCode.RESULT_INVALID_MODEL_HEADER_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_HEADER_ERROR,
+                ResultCode.RESULT_INVALID_MODEL_FORMAT_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_FORMAT_ERROR,
                 ResultCode.RESULT_MODEL_ALREADY_LOADED_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_MODEL_ALREADY_LOADED_ERROR,
                 ResultCode.RESULT_STYLE_ALREADY_LOADED_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_STYLE_ALREADY_LOADED_ERROR,
                 ResultCode.RESULT_INVALID_MODEL_DATA_ERROR => VoicevoxResultCode.VOICEVOX_RESULT_INVALID_MODEL_DATA_ERROR,

--- a/src/VoicevoxCoreSharp.Core/Native/CoreUnsafe.g.cs
+++ b/src/VoicevoxCoreSharp.Core/Native/CoreUnsafe.g.cs
@@ -22,30 +22,50 @@ namespace VoicevoxCoreSharp.Core.Native
 
 
         /// <summary>
-        ///  ONNX Runtimeの動的ライブラリの、バージョン付きのファイル名。
+        ///  必要なONNX Runtime 1.xの最小マイナーバージョンを取得する。
         ///
-        ///  WindowsとAndroidでは ::voicevox_get_onnxruntime_lib_unversioned_filename と同じ。
+        ///  @return 必要な最小マイナーバージョン
         ///
-        ///  \availability{
-        ///    [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は&lt;a href="#voicevox-core-availability"&gt;ファイルレベルの"Availability"の節&lt;/a&gt;を参照。
-        ///  }
-        ///
-        ///  \orig-impl{voicevox_get_onnxruntime_lib_versioned_filename}
+        ///  \orig-impl{voicevox_get_onnxruntime_lib_min_required_minor_version}
         /// </summary>
-        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_versioned_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern byte* voicevox_get_onnxruntime_lib_versioned_filename();
+        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_min_required_minor_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern uint voicevox_get_onnxruntime_lib_min_required_minor_version();
 
         /// <summary>
-        ///  ONNX Runtimeの動的ライブラリの、バージョン無しのファイル名。
+        ///  サポートされるONNX Runtime 1.xの最大マイナーバージョンを取得する。
+        ///
+        ///  @return サポートされる最大マイナーバージョン
+        ///
+        ///  \orig-impl{voicevox_get_onnxruntime_lib_max_supported_minor_version}
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_max_supported_minor_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern uint voicevox_get_onnxruntime_lib_max_supported_minor_version();
+
+        /// <summary>
+        ///  推奨されるONNX Runtimeの動的ライブラリの、バージョン付きのファイル名。
+        ///
+        ///  WindowsとAndroidでは ::voicevox_get_onnxruntime_lib_recommended_unversioned_filename と同じ。
         ///
         ///  \availability{
         ///    [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は&lt;a href="#voicevox-core-availability"&gt;ファイルレベルの"Availability"の節&lt;/a&gt;を参照。
         ///  }
         ///
-        ///  \orig-impl{voicevox_get_onnxruntime_lib_unversioned_filename}
+        ///  \orig-impl{voicevox_get_onnxruntime_lib_recommended_versioned_filename}
         /// </summary>
-        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_unversioned_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern byte* voicevox_get_onnxruntime_lib_unversioned_filename();
+        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_recommended_versioned_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern byte* voicevox_get_onnxruntime_lib_recommended_versioned_filename();
+
+        /// <summary>
+        ///  推奨されるONNX Runtimeの動的ライブラリの、バージョン無しのファイル名。
+        ///
+        ///  \availability{
+        ///    [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は&lt;a href="#voicevox-core-availability"&gt;ファイルレベルの"Availability"の節&lt;/a&gt;を参照。
+        ///  }
+        ///
+        ///  \orig-impl{voicevox_get_onnxruntime_lib_recommended_unversioned_filename}
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "voicevox_get_onnxruntime_lib_recommended_unversioned_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern byte* voicevox_get_onnxruntime_lib_recommended_unversioned_filename();
 
         /// <summary>
         ///  デフォルトの ::voicevox_onnxruntime_load_once のオプションを生成する。
@@ -76,6 +96,8 @@ namespace VoicevoxCoreSharp.Core.Native
         /// <summary>
         ///  ONNX Runtimeをロードして初期化する。
         ///
+        ///  対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_minor_version 以上でなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
+        ///
         ///  一度成功したら、以後は引数を無視して同じ参照を返す。
         ///
         ///  @param [in] options オプション
@@ -99,6 +121,8 @@ namespace VoicevoxCoreSharp.Core.Native
 
         /// <summary>
         ///  ONNX Runtimeを初期化する。
+        ///
+        ///  リンクされているONNX Runtimeのマイナーバージョンが ::voicevox_get_onnxruntime_lib_min_required_minor_version よりも小さい場合失敗する。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
         ///
         ///  一度成功したら以後は同じ参照を返す。
         ///
@@ -236,19 +260,13 @@ namespace VoicevoxCoreSharp.Core.Native
         ///
         ///  - [Rust APIの`AudioQuery`型]としてデシリアライズ不可、もしくはJSONとして不正。
         ///  - `accent_phrases`の要素のうちいずれかが、 ::voicevox_accent_phrase_validate でエラーになる。
-        ///  - `outputSamplingRate`が`24000`の倍数ではない、もしくは`0` (将来的に解消予定。cf. [#762])。
         ///
         ///  [Rust APIの`AudioQuery`型]: ../rust_api/voicevox_core/struct.AudioQuery.html
         ///  [#762]: https://github.com/VOICEVOX/voicevox_core/issues/762
         ///
         ///  次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
         ///
-        ///  - `accent_phrases`の要素のうちいずれかが警告が出る状態。
-        ///  - `speedScale`が負。
-        ///  - `volumeScale`が負。
-        ///  - `prePhonemeLength`が負。
-        ///  - `postPhonemeLength`が負。
-        ///  - `outputSamplingRate`が`24000`以外の値（エラーと同様将来的に解消予定）。
+        ///  - `outputSamplingRate`が`24000`以外の値（将来的に解消予定。cf. [#762]）。
         ///
         ///  @param [in] audio_query_json `AudioQuery`型のJSON
         ///
@@ -270,14 +288,9 @@ namespace VoicevoxCoreSharp.Core.Native
         ///
         ///  - [Rust APIの`AccentPhrase`型]としてデシリアライズ不可、もしくはJSONとして不正。
         ///  - `moras`もしくは`pause_mora`の要素のうちいずれかが、 ::voicevox_mora_validate でエラーになる。
-        ///  - `accent`が`0`。
+        ///  - `accent`が`moras`の数を超過している。
         ///
         ///  [Rust APIの`AccentPhrase`型]: ../rust_api/voicevox_core/struct.AccentPhrase.html
-        ///
-        ///  次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
-        ///
-        ///  - `moras`もしくは`pause_mora`の要素のうちいずれかが、警告が出る状態。
-        ///  - `accent`が`moras`の数を超過している。
         ///
         ///  @param [in] accent_phrase_json `AccentPhrase`型のJSON
         ///
@@ -299,15 +312,8 @@ namespace VoicevoxCoreSharp.Core.Native
         ///
         ///  - [Rust APIの`Mora`型]としてデシリアライズ不可、もしくはJSONとして不正。
         ///  - `consonant`と`consonant_length`の有無が不一致。
-        ///  - `consonant`が子音以外の音素であるか、もしくは音素として不正。
-        ///  - `vowel`が子音であるか、もしくは音素として不正。
         ///
         ///  [Rust APIの`Mora`型]: ../rust_api/voicevox_core/struct.Mora.html
-        ///
-        ///  次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
-        ///
-        ///  - `consonant_length`が負。
-        ///  - `vowel_length`が負。
         ///
         ///  @param [in] mora_json `Mora`型のJSON
         ///
@@ -1414,7 +1420,7 @@ namespace VoicevoxCoreSharp.Core.Native
         public byte* pronunciation;
         public nuint accent_type;
         public VoicevoxUserDictWordType word_type;
-        public uint priority;
+        public byte priority;
     }
 
 
@@ -1435,7 +1441,7 @@ namespace VoicevoxCoreSharp.Core.Native
         VOICEVOX_RESULT_INVALID_ACCENT_PHRASE_ERROR = 15,
         VOICEVOX_RESULT_OPEN_ZIP_FILE_ERROR = 16,
         VOICEVOX_RESULT_READ_ZIP_ENTRY_ERROR = 17,
-        VOICEVOX_RESULT_INVALID_MODEL_HEADER_ERROR = 28,
+        VOICEVOX_RESULT_INVALID_MODEL_FORMAT_ERROR = 28,
         VOICEVOX_RESULT_MODEL_ALREADY_LOADED_ERROR = 18,
         VOICEVOX_RESULT_STYLE_ALREADY_LOADED_ERROR = 26,
         VOICEVOX_RESULT_INVALID_MODEL_DATA_ERROR = 27,

--- a/src/VoicevoxCoreSharp.Core/Onnxruntime.cs
+++ b/src/VoicevoxCoreSharp.Core/Onnxruntime.cs
@@ -38,19 +38,35 @@ namespace VoicevoxCoreSharp.Core
             Handle = new OnnxruntimeHandle(new IntPtr(onnxruntimeHandle));
         }
 
-        public static string GetVersionedFilename()
+        public static uint GetMinRequiredMinorVersion()
         {
             unsafe
             {
-                return StringConvertCompat.ToUTF8String(CoreUnsafe.voicevox_get_onnxruntime_lib_versioned_filename());
+                return CoreUnsafe.voicevox_get_onnxruntime_lib_min_required_minor_version();
             }
         }
 
-        public static string GetUnversionedFilename()
+        public static uint GetMaxSupportedMinorVersion()
         {
             unsafe
             {
-                return StringConvertCompat.ToUTF8String(CoreUnsafe.voicevox_get_onnxruntime_lib_unversioned_filename());
+                return CoreUnsafe.voicevox_get_onnxruntime_lib_max_supported_minor_version();
+            }
+        }
+
+        public static string GetRecommendedVersionedFilename()
+        {
+            unsafe
+            {
+                return StringConvertCompat.ToUTF8String(CoreUnsafe.voicevox_get_onnxruntime_lib_recommended_versioned_filename());
+            }
+        }
+
+        public static string GetRecommendedUnversionedFilename()
+        {
+            unsafe
+            {
+                return StringConvertCompat.ToUTF8String(CoreUnsafe.voicevox_get_onnxruntime_lib_recommended_unversioned_filename());
             }
         }
 

--- a/src/VoicevoxCoreSharp.Core/Struct/UserDictWord.cs
+++ b/src/VoicevoxCoreSharp.Core/Struct/UserDictWord.cs
@@ -38,7 +38,7 @@ namespace VoicevoxCoreSharp.Core.Struct
         /// <summary>
         /// 優先度
         /// </summary>
-        public uint Priority { get; set; }
+        public byte Priority { get; set; }
 
         public static UserDictWord Create(string surface, string pronunciation, nuint accentType)
         {

--- a/src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.Metas.props
+++ b/src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.Metas.props
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
-        <VoicevoxOnnxRuntimeVersion>1.17.3</VoicevoxOnnxRuntimeVersion>
-        <VoicevoxCoreCommitHash>8bbbd86689f08ff68b89b4e9d8296919bfce83e9</VoicevoxCoreCommitHash>
+        <!-- ref: binding/voicevox_core/crates/voicevox_core/onnxruntime-recommended-version.txt -->
+        <VoicevoxOnnxRuntimeVersion>1.23.2</VoicevoxOnnxRuntimeVersion>
+        <VoicevoxCoreCommitHash>8f4e299c10b181cc5058d32b1a492999b5c2b2c4</VoicevoxCoreCommitHash>
     </PropertyGroup>
 </Project>

--- a/src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.csproj
+++ b/src/VoicevoxCoreSharp.Core/VoicevoxCoreSharp.Core.csproj
@@ -29,7 +29,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!-- when packaging, dotnet pack -p:PackageVersion=0.16.0 -c Release -->
+    <!-- when packaging, dotnet pack -p:PackageVersion=0.17.0 -c Release -->
     <!-- <Version>0.0.0</Version> -->
   </PropertyGroup>
 

--- a/src/VoicevoxCoreSharp.Experimental/README.md
+++ b/src/VoicevoxCoreSharp.Experimental/README.md
@@ -10,7 +10,7 @@ API は予告なく変更される場合があります。
 
 ### 非同期 API
 
-クラス名に `Extensions` が付属していないメソッドは、VoiceVoxCoreSharp.Core で提供するクラスの拡張メソッドとして提供されています。
+クラス名に `Extensions` が付属していないメソッドは、VoicevoxCoreSharp.Core で提供するクラスの拡張メソッドとして提供されています。
 
 - OnnxruntimeExtensions.LoadOnceAsync
 - OnnxruntimeExtensions.InitOnceAsync

--- a/src/VoicevoxCoreSharp.Experimental/VoicevoxCoreSharp.Experimental.csproj
+++ b/src/VoicevoxCoreSharp.Experimental/VoicevoxCoreSharp.Experimental.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
-  <!-- dotnet pack -p:CoreVersion=0.16.0 -p:PackageVersion=0.16.0 -->
+  <!-- dotnet pack -p:CoreVersion=0.17.0 -p:PackageVersion=0.17.0 -->
   <Target Name="SetDependencyVersion" AfterTargets="_GetProjectReferenceVersions">
     <ItemGroup>
       <_ProjectReferencesWithVersions Update="..\VoicevoxCoreSharp.Core\VoicevoxCoreSharp.Core.csproj" ProjectVersion="$(CoreVersion)" />

--- a/src/VoicevoxCoreSharp.MAUI/VoicevoxCoreSharp.MAUI.csproj
+++ b/src/VoicevoxCoreSharp.MAUI/VoicevoxCoreSharp.MAUI.csproj
@@ -51,7 +51,7 @@
 	</ItemGroup>
 
 	<!-- https://blog.azyobuzi.net/2020/05/03/01-projectref/ -->
-	<!-- dotnet pack -p:CoreVersion=0.16.0 -p:PackageVersion=0.16.0 -->
+	<!-- dotnet pack -p:CoreVersion=0.17.0 -p:PackageVersion=0.17.0 -->
 	<Target Name="SetDependencyVersion" AfterTargets="_GetProjectReferenceVersions">
 		<ItemGroup>
 			<_ProjectReferencesWithVersions Update="..\VoicevoxCoreSharp.Core\VoicevoxCoreSharp.Core.csproj" ProjectVersion="$(CoreVersion)" />

--- a/tests/VoicevoxCoreSharp.Core.Tests/UserDictTest.cs
+++ b/tests/VoicevoxCoreSharp.Core.Tests/UserDictTest.cs
@@ -39,7 +39,7 @@ namespace VoicevoxCoreSharp.Core.Tests
             var userDict = new UserDict();
 
             var pronunciation = "ホゲ";
-            uint priority = 10;
+            byte priority = 10;
             nuint accentType = 2;
             var wordType = UserDictWordType.ADJECTIVE;
 


### PR DESCRIPTION
This pull request updates the project to support voicevox_core version 0.17.0 and ONNX Runtime 1.23.2, along with several related changes to improve compatibility and align with upstream updates. The most important changes include updating dependency versions, adjusting native bindings, and making minor corrections to enums and documentation.

**Dependency and Version Updates:**

* Upgraded voicevox_core to version `0.17.0` and ONNX Runtime to `1.23.2` throughout the project, including documentation, build scripts, and sample projects (`README.md`, `examples/MAUI/README.md`, `examples/cli/README.md`, `.github/workflows/csharp_test.yml`, `examples/MAUI/MAUI.csproj`, `examples/MAUI/MainPageViewModel.cs`, `examples/UnitySample/Assets/SampleVoicevoxCoreSharpScript.cs`, `VERSIONS.md`, `binding/voicevox_core`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R20) [[2]](diffhunk://#diff-477e0dcc09810b6bf474b50bea5071879ad9a2454207dcf220a74e0c3673a64cL3-R3) [[3]](diffhunk://#diff-477e0dcc09810b6bf474b50bea5071879ad9a2454207dcf220a74e0c3673a64cL23-R31) [[4]](diffhunk://#diff-d3f71215480742d566e7f44a2e2dabf65f901eb52f8d9efe92fd1f1c8372cb0bL15-R15) [[5]](diffhunk://#diff-d049a01a6fa54de4e62abef0d70ce5ed442c2387c212f9302aae1420b87c60daL88-R88) [[6]](diffhunk://#diff-482465254147249f2de2c177165dacfe82e02cd7ba93cf821307a5956195b9b7L93-R102) [[7]](diffhunk://#diff-ccd225980b696a01e2517876b95d630d80bb0d10fd26006a6507123470b1a90fL59-R59) [[8]](diffhunk://#diff-ccd225980b696a01e2517876b95d630d80bb0d10fd26006a6507123470b1a90fL110-R110) [[9]](diffhunk://#diff-96ec3a774d4f1f23da55e4ba15cfeaa83877027c05e1dce460ecc715fd9ac4abL31-R31) [[10]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeL13-R14) [[11]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeR25-R28) [[12]](diffhunk://#diff-d8a7120196995f9613a029eda1eefb05581aec176ca83652526c895843a967d3L1-R1)

**Native Binding and API Updates:**

* Updated native bindings in `CoreUnsafe.g.cs` to add new functions for retrieving the minimum and maximum supported ONNX Runtime minor versions, and switched to using the recommended filename functions for ONNX Runtime libraries. Also updated function documentation to reflect upstream changes and new version requirements. [[1]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L25-R68) [[2]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622R99-R100) [[3]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622R125-R126)
* Changed the type of `priority` in `VoicevoxUserDictWord` from `uint` to `byte` to match upstream changes.

**Enum and Result Code Adjustments:**

* Renamed `RESULT_INVALID_MODEL_HEADER_ERROR` to `RESULT_INVALID_MODEL_FORMAT_ERROR` in both the managed and native enums for consistency with upstream. Updated all relevant mappings. [[1]](diffhunk://#diff-9fa7c164bc1e5f1a1d9661cab92daeede0bd51238937f84a8194968dbc4daf19L74-R74) [[2]](diffhunk://#diff-9fa7c164bc1e5f1a1d9661cab92daeede0bd51238937f84a8194968dbc4daf19L159-R159) [[3]](diffhunk://#diff-9fa7c164bc1e5f1a1d9661cab92daeede0bd51238937f84a8194968dbc4daf19L199-R199) [[4]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L1438-R1444)

**Documentation and Sample Code Corrections:**

* Updated comments and documentation to reflect new validation logic and error/warning conditions, particularly for audio query, accent phrase, and mora validation functions. [[1]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L239-R269) [[2]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L273-L281) [[3]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L302-L311)

These changes ensure the project remains compatible with the latest voicevox_core and ONNX Runtime releases, and align the codebase with upstream API and documentation updates.This pull request updates the project to support voicevox_core version 0.17.0 and ONNX Runtime 1.23.2, along with several improvements and code cleanups. The most significant changes are version upgrades across the codebase, updates to native bindings for new ONNX Runtime APIs, and some refinements to error codes and documentation in the C# bindings.

**Version Upgrades and Dependency Updates**
* Updated all references, scripts, and documentation to use `voicevox_core` version 0.17.0 and ONNX Runtime 1.23.2, replacing the previous 0.16.0/1.17.3 versions. This includes changes in sample projects, workflow scripts, and download instructions. [[1]](diffhunk://#diff-482465254147249f2de2c177165dacfe82e02cd7ba93cf821307a5956195b9b7L93-R102) [[2]](diffhunk://#diff-ccd225980b696a01e2517876b95d630d80bb0d10fd26006a6507123470b1a90fL59-R59) [[3]](diffhunk://#diff-ccd225980b696a01e2517876b95d630d80bb0d10fd26006a6507123470b1a90fL110-R110) [[4]](diffhunk://#diff-96ec3a774d4f1f23da55e4ba15cfeaa83877027c05e1dce460ecc715fd9ac4abL31-R31) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R20) [[6]](diffhunk://#diff-477e0dcc09810b6bf474b50bea5071879ad9a2454207dcf220a74e0c3673a64cL3-R3) [[7]](diffhunk://#diff-477e0dcc09810b6bf474b50bea5071879ad9a2454207dcf220a74e0c3673a64cL23-R31) [[8]](diffhunk://#diff-d3f71215480742d566e7f44a2e2dabf65f901eb52f8d9efe92fd1f1c8372cb0bL15-R15) [[9]](diffhunk://#diff-d049a01a6fa54de4e62abef0d70ce5ed442c2387c212f9302aae1420b87c60daL88-R88) [[10]](diffhunk://#diff-d8a7120196995f9613a029eda1eefb05581aec176ca83652526c895843a967d3L1-R1) [[11]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeL13-R14) [[12]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeR25-R28)

**C# Native Binding and API Improvements**
* Added new P/Invoke bindings in `CoreUnsafe.g.cs` for ONNX Runtime version queries: functions to get the minimum required and maximum supported minor versions, and updated the recommended filename APIs to match upstream changes.
* Updated documentation comments for ONNX Runtime loading/initialization to clarify version compatibility and warning behavior. [[1]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622R99-R100) [[2]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622R125-R126)
* Adjusted field types and enum values in native struct and enums to match upstream changes: changed `VoicevoxUserDictWord.priority` from `uint` to `byte` and renamed error codes from `INVALID_MODEL_HEADER_ERROR` to `INVALID_MODEL_FORMAT_ERROR`. [[1]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L1417-R1423) [[2]](diffhunk://#diff-9fa7c164bc1e5f1a1d9661cab92daeede0bd51238937f84a8194968dbc4daf19L74-R74) [[3]](diffhunk://#diff-9fa7c164bc1e5f1a1d9661cab92daeede0bd51238937f84a8194968dbc4daf19L159-R159) [[4]](diffhunk://#diff-9fa7c164bc1e5f1a1d9661cab92daeede0bd51238937f84a8194968dbc4daf19L199-R199) [[5]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L1438-R1444)

**Documentation and Sample Code Updates**
* Updated documentation and comments to reflect the new versions and clarify error/warning conditions in API usage, especially around accent phrase and mora validation. [[1]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L239-R269) [[2]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L273-L281) [[3]](diffhunk://#diff-dafc9ebe9e49a704ac954b82904c42964939c7ddc0f15a1b825e3b7a7ac97622L302-L311)

These changes keep the project in sync with the latest voicevox_core features and requirements, and improve clarity and correctness in the C# bindings and related documentation.